### PR TITLE
Add paf-iast.edu.pk — Pak-Austria Fachhochschule Institute of Applied Sciences and Technology

### DIFF
--- a/lib/domains/pk/edu/paf-iast.txt
+++ b/lib/domains/pk/edu/paf-iast.txt
@@ -1,0 +1,1 @@
+Pak-Austria Fachhochschule Institute of Applied Sciences and Technology


### PR DESCRIPTION
Official name: Pak-Austria Fachhochschule Institute of Applied Sciences and Technology  
Official website: https://paf-iast.edu.pk  
IT Departments Link: https://paf-iast.edu.pk/school_of_computingsciences/